### PR TITLE
Replace DB_MASTER with DB_PRIMARY

### DIFF
--- a/src/PackagePrivate/DatabaseIdGenerator.php
+++ b/src/PackagePrivate/DatabaseIdGenerator.php
@@ -18,7 +18,7 @@ class DatabaseIdGenerator implements IdGenerator {
 	}
 
 	public function getNewId( string $type = '' ): int {
-		$database = $this->loadBalancer->getConnection( DB_MASTER );
+		$database = $this->loadBalancer->getConnection( DB_PRIMARY );
 
 		$database->startAtomic( __METHOD__ );
 


### PR DESCRIPTION
DB_MASTER was deprecated in MediaWiki 1.36 and removed in MediaWiki 1.43